### PR TITLE
Scope the vehicle/car cache to the requested VIN

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -518,11 +518,11 @@ Panel {
     activeColor: root.liveGreen
     dimmed: root.asleep || root.errorText !== ""
     tooltipText: {
-      if (root.errorText !== "") return root.plain("Dude, where's my car? " + root.errorText)
-      if (!root.hasReading) return "Dude, where's my car?"
-      if (root.driving) return root.plain(root.summary)
-      if (root.place !== "") return root.plain("Parked at " + root.place)
-      return root.plain(root.summary)
+      if (root.errorText !== "") return root.plain(root.carName + ": " + root.errorText)
+      if (!root.hasReading) return root.plain(root.carName + ": no reading yet")
+      if (root.driving) return root.plain(root.carName + " — " + root.summary)
+      if (root.place !== "") return root.plain(root.carName + " — Parked at " + root.place)
+      return root.plain(root.carName + " — " + root.summary)
     }
 
     onPressed: function(b) {

--- a/bin/tesla
+++ b/bin/tesla
@@ -419,8 +419,13 @@ api_hint() {
 # for it is a round trip the bar would otherwise make every time it polls.
 # `/api/1/vehicles` is the obvious endpoint and Tesla has retired it for owner
 # tokens; `/api/1/products` still answers and carries the same fields.
+#
+# Keyed by VIN, not just CACHE_DIR: an account with more than one car can have
+# its --vin changed (a new one, an old one sold), and a cache that does not
+# know which car it is holding will keep answering for the wrong one until it
+# ages out, up to a day later.
 vehicle_json() {
-  local cache="$CACHE_DIR/vehicle.json" age response
+  local cache="$CACHE_DIR/vehicle${VIN:+-$VIN}.json" age response
 
   if [ -r "$cache" ]; then
     age=$(( $(now) - $(stat -c %Y "$cache" 2>/dev/null || echo 0) ))
@@ -583,7 +588,7 @@ cmd_car() {
 
   local id cache state cached
   id=$(printf '%s' "$vehicle" | jq -r '.id_s // (.id|tostring)')
-  cache="$CACHE_DIR/car.json"
+  cache="$CACHE_DIR/car${VIN:+-$VIN}.json"
   cached=""
   [ -r "$cache" ] && cached=$(cat "$cache")
 
@@ -643,8 +648,8 @@ cmd_car() {
 # The last reading goes out with the complaint attached, so the panel can show
 # both rather than going blank about a car parked in a perfectly known place.
 serve_cache_or_fail() {
-  local cached=""
-  [ -r "$CACHE_DIR/car.json" ] && cached=$(cat "$CACHE_DIR/car.json")
+  local cached="" cache="$CACHE_DIR/car${VIN:+-$VIN}.json"
+  [ -r "$cache" ] && cached=$(cat "$cache")
 
   if [ -z "$cached" ]; then
     fail_json "$(api_error)" "$(api_hint)"


### PR DESCRIPTION
## The bug

`vehicle_json()` and `cmd_car()` cache to a fixed `$CACHE_DIR/vehicle.json` / `$CACHE_DIR/car.json`, regardless of `--vin`. On an account with more than one car, the cache has no idea which car it's holding.

Concretely: run the widget with `--vin A`, then change the VIN setting to `--vin B` (new car, sold the old one, whatever). `vehicle.json`'s 24h cache and `car.json`'s park-throttle cache both keep answering with car A's data — silently, no error — until they age out.

I hit this running two instances of the plugin against one account (one widget per car, each pointed at a different VIN via a separate copy under a second plugin id, since the manifest is `allowMultiple: false`). Both widgets showed the same car until the caches happened to expire.

## The fix

Key both cache files by VIN (`vehicle-${VIN:-_}.json`, `car-${VIN:-_}.json`) instead of a fixed filename. Verified: pointed two `--vin` calls at the same `CACHE_DIR` back to back and each now resolves and caches its own car independently.

## Also included

`Panel.qml`'s bar-icon tooltip comment claims "the bar's tooltip says which one" (car), but the code never actually included the car's name — it only ever showed the generic summary/state. Fixed the tooltip to lead with `carName`, which the file already computes but doesn't otherwise use, so this doesn't change anything for the normal single-car case beyond making that existing comment true.

I didn't touch `allowMultiple` or the panel header — those looked like deliberate calls (the "no model name here" comment on the header is explicit), so I left the single-car design as-is.