### PR TITLE
US localization: address order and tires/trunk

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -133,21 +133,25 @@ Panel {
   property var reading: null
   // The tile plan for the position in `reading`.
   property var mapPlan: null
-  // The position in `reading`, as a street and a town. Kept in parts, because
-  // the house number is worth having when the car is parked and noise when it
-  // is moving.
+  // Parked line comes pre-joined from `tesla place` (number-first or
+  // number-last by the country of the pin). Street and town are kept so a
+  // moving car can drop the house number without another lookup.
   property string placeStreet: ""
-  property string placeNumber: ""
   property string placeTown: ""
+  property string placeParked: ""
+
+  readonly property bool usEnglish: {
+    var name = String(Qt.locale().name).replace(/-/g, "_").replace(/\.[^.]+$/, "")
+    return name.indexOf("en_US") === 0 || name.indexOf("en_CA") === 0
+  }
 
   // At speed the nearest address changes every second, so the number is
-  // dropped and only the road is named: "De Hees, Kronenberg" holds still
-  // while "De Hees 39" flickers through the whole street.
+  // dropped and only the road is named. Parked, the script's `place` is the
+  // whole line.
   readonly property string place: {
-    if (placeStreet === "" && placeTown === "") return ""
-    var head = placeStreet
-    if (!driving && placeNumber !== "" && head !== "") head += " " + placeNumber
-    return [head, placeTown].filter(function(part) { return part !== "" }).join(", ")
+    if (driving)
+      return [placeStreet, placeTown].filter(function(part) { return part !== "" }).join(", ")
+    return placeParked
   }
   property string errorText: ""
   // The sentence behind the error, when the script has one. Kept apart so the
@@ -324,12 +328,12 @@ Panel {
           var data = JSON.parse(text)
           var ok = data.ok === true
           root.placeStreet = ok ? (data.street || "") : ""
-          root.placeNumber = ok ? (data.number || "") : ""
           root.placeTown = ok ? (data.town || "") : ""
+          root.placeParked = ok ? (data.place || "") : ""
         } catch (e) {
           root.placeStreet = ""
-          root.placeNumber = ""
           root.placeTown = ""
+          root.placeParked = ""
         }
       }
     }
@@ -445,7 +449,9 @@ Panel {
   // that is usually absent gets read on the day it appears.
   readonly property string openText: {
     if (!hasReading || !reading.open || reading.open.length === 0) return ""
-    var items = reading.open
+    var items = reading.open.map(function(item) {
+      return (root.usEnglish && item === "the boot") ? "the trunk" : item
+    })
     var list = items.length === 1
       ? items[0]
       : items.slice(0, -1).join(", ") + " and " + items[items.length - 1]
@@ -798,7 +804,7 @@ Panel {
         }
 
         Detail {
-          label: "tyres"
+          label: root.usEnglish ? "tires" : "tyres"
           // A range rather than four numbers: what you act on is the lowest
           // one, and what tells you something is wrong is the spread.
           value: {

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ corner of your eye.
 - The street it is on, and one line saying what it is doing and how old the
   whole reading is: `Driving 53 km/h · fetched just now`. Everything on the
   panel came out of that one reading, so one line dates all of it. Parked, the
-  street comes with its house number; moving, it does not, because at speed the
+  street comes with its house number, in the order that country writes it
+  (`1600 Pennsylvania Avenue Northwest, Washington, DC` in the US; `De Hees 39,
+  Kronenberg` in the Netherlands); moving, it does not, because at speed the
   nearest address changes every second and the line flickers through numbers
   nobody is reading.
 - The battery bar with the charge limit notched on it, and under it the

--- a/bin/place.jq
+++ b/bin/place.jq
@@ -1,0 +1,26 @@
+# Nominatim reverse jsonv2 → glance-line contract.
+# Address fields come from .address. display_name is a sibling and must not leak.
+.address as $a
+| ($a.road // $a.pedestrian // $a.footway // "") as $road
+| ($a.house_number // "") as $number
+| ($a.village // $a.town // $a.city // $a.suburb // $a.municipality // "") as $locality
+| (($a.country_code // "") | ascii_downcase) as $cc
+| (["us", "ca", "gb", "ie", "au", "nz", "fr"] | index($cc) != null) as $number_first
+| (["us", "ca", "au"] | index($cc) != null) as $want_region
+| ($a["ISO3166-2-lvl4"] // "") as $iso
+| (if ($iso | type == "string") and ($iso | test("-"))
+   then ($iso | sub("^[^-]*-"; ""))
+   else "" end) as $region
+| (if $want_region and ($locality != "") and ($region != "")
+   then $locality + ", " + $region
+   else $locality end) as $town
+| (if $number_first and ($number != "") and ($road != "")
+   then $number + " " + $road
+   else ([$road, $number] | map(select(. != "")) | join(" "))
+   end) as $head
+| {ok: true,
+   street: $road,
+   number: $number,
+   town: $town,
+   number_first: $number_first,
+   place: ([$head, $town] | map(select(. != "")) | join(", "))}

--- a/bin/tesla
+++ b/bin/tesla
@@ -72,6 +72,13 @@ readonly TLS_PIN="--tlsv1.3"
 CONFIG_DIR="${OMARCHY_TESLA_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/omarchy-tesla}"
 CACHE_DIR="${OMARCHY_TESLA_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/omarchy-tesla}"
 
+# Plugin files sit next to this script. The panel runs us by absolute path, so
+# cwd is not the plugin dir.
+here=$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+PLACE_JQ="$here/place.jq"
+# Cache files from before country-aware formatting lack number_first.
+PLACE_CACHE_USABLE='.ok == true and (.number_first | type == "boolean")'
+
 # Seconds a parked, awake car is left alone between readings. Tesla needs
 # roughly a quarter of an hour of quiet before it sleeps, so anything shorter
 # than this would hold it awake forever.
@@ -165,6 +172,13 @@ serve_fixture() {
 write_private() {
   local path="$1"
   ( umask 077; cat > "$path" )
+}
+
+# A place-cache file is usable only when it was written by place.jq.
+# jq -e prints true/false; discard that or a cache hit becomes two lines.
+place_cache_usable() {
+  [ -s "$1" ] || return 1
+  jq -e "$PLACE_CACHE_USABLE" "$1" >/dev/null 2>&1
 }
 
 read_first_line() {
@@ -738,9 +752,14 @@ fetch_tile() {
 # Where the car is, in words. Nominatim asks for no more than one call a
 # second and would rather you cached; coordinates are rounded to about ten
 # metres first, so a car sitting still is one lookup however often you look.
+#
+# Formatting lives in place.jq, next to this script: country of the pin
+# decides number-first vs number-last, and US/CA/AU get a region suffix.
+# The parked line is `place`. The panel drops the house number on screen
+# while moving; this cache is keyed by coordinates, so it does not change.
 cmd_place() {
   local lat="$1" lon="$2"
-  local key path response
+  local key path response formatted
 
   # Same check `map` makes. These are pasted straight into a query string, and
   # a coordinate that is not a number is not a coordinate.
@@ -751,31 +770,17 @@ cmd_place() {
   key=$(awk -v a="$lat" -v b="$lon" 'BEGIN { printf "%.4f_%.4f", a, b }')
   path="$CACHE_DIR/places/$key.json"
 
-  if [ -s "$path" ]; then cat "$path"; return 0; fi
+  if place_cache_usable "$path"; then cat "$path"; return 0; fi
+
+  [ -f "$PLACE_JQ" ] || fail_json "no address" "place.jq is missing next to bin/tesla"
 
   response=$(curl -sS -f -m 20 -A "$MAP_UA" \
     "https://nominatim.openstreetmap.org/reverse?format=jsonv2&zoom=18&lat=$lat&lon=$lon" 2>/dev/null) \
     || fail_json "no address"
 
-  # A street and a town is what you want to read; the full display_name is a
-  # paragraph ending in the country you are standing in.
-  #
-  # The house number comes back on its own as well as folded into `place`,
-  # because it is worth having when the car is parked and noise when it is
-  # moving: at speed the nearest address changes every second and the line
-  # flickers through numbers nobody is reading.
-  printf '%s' "$response" | jq -c '
-    .address as $a
-    | ($a.road // $a.pedestrian // $a.footway // "") as $road
-    | ($a.house_number // "") as $number
-    | ($a.village // $a.town // $a.city // $a.suburb // $a.municipality // "") as $town
-    | {ok: true,
-       street: $road,
-       number: $number,
-       town: $town,
-       place: ([[$road, $number] | map(select(. != "")) | join(" "), $town]
-               | map(select(. != "")) | join(", "))}' | write_private "$path"
-
+  formatted=$(printf '%s' "$response" | jq -c -f "$PLACE_JQ") || fail_json "no address"
+  [ -n "$formatted" ] || fail_json "no address"
+  printf '%s' "$formatted" | write_private "$path"
   cat "$path"
 }
 

--- a/tests/MANUAL.md
+++ b/tests/MANUAL.md
@@ -1,0 +1,51 @@
+# Manual checks (no QML test runner)
+
+Copy and the parked tooltip live in the panel. `tests/place.sh` does not cover them.
+
+Do not run live `tesla place` against the car as a test. Old cache files miss and that would hit Nominatim.
+
+## Fixture for the open sentence
+
+Copy a reading, then set the rear trunk token:
+
+```
+tesla car > ~/.config/omarchy-tesla/fixture.json
+```
+
+Edit `open` to `["the boot"]`. Delete the file when done.
+
+## C1 — this machine, US English (`en_US`)
+
+- Details label reads `tires`, not `tyres`.
+- With the fixture above, the red line reads `The trunk is open`.
+- Parked tooltip is `Parked at ` plus the glance line, unelided.
+- Glance line may elide at panel width. Do not wrap it.
+
+## C2 — `en_CA`
+
+Restart the bar with `LC_ALL=en_CA.UTF-8` if Qt picks that up. Same as C1 (`tires`, `The trunk is open`). If the bar ignores a one-shot `LC_ALL`, write unverified here rather than guessing.
+
+## C3 — `en_GB` / `en_AU` / `nl_NL`
+
+Restart with `LC_ALL=en_GB.UTF-8` (or `en_AU` / `nl_NL`). Label `tyres`. Fixture sentence `The boot is open`.
+
+## C4 — US desktop, Dutch pin
+
+Address follows the pin; copy follows the desktop. Do not call live Nominatim. Seed the place cache for the car's rounded coordinates with the A3 contract, then open the panel.
+
+```
+lat=$(jq -r .lat ~/.cache/omarchy-tesla/car.json)
+lon=$(jq -r .lon ~/.cache/omarchy-tesla/car.json)
+key=$(awk -v a="$lat" -v b="$lon" 'BEGIN { printf "%.4f_%.4f", a, b }')
+cp tests/fixtures/a3.out.json ~/.cache/omarchy-tesla/places/$key.json
+```
+
+Glance line: `Venweg 12, Kronenberg`. Label: `tires`. Remove the seeded file afterwards.
+
+## A2 — moving
+
+IPC `omarchy-shell jankeesvw.tesla.test drive 87 243` (or drive the car). Glance line drops the house number. Street and town stay, including a US `, PA` / `, DC` suffix.
+
+## A14 — tooltip
+
+Parked, with a place: tooltip is `Parked at ` plus the same string as the glance line.

--- a/tests/fixtures/a1.in.json
+++ b/tests/fixtures/a1.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "1600",
+    "road": "Pennsylvania Avenue Northwest",
+    "city": "Washington",
+    "country_code": "us",
+    "ISO3166-2-lvl4": "US-DC",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a1.out.json
+++ b/tests/fixtures/a1.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Pennsylvania Avenue Northwest","number":"1600","town":"Washington, DC","number_first":true,"place":"1600 Pennsylvania Avenue Northwest, Washington, DC"}

--- a/tests/fixtures/a10.in.json
+++ b/tests/fixtures/a10.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "1",
+    "road": "Queen Street",
+    "city": "Auckland",
+    "country_code": "nz",
+    "ISO3166-2-lvl4": "NZ-AUK",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a10.out.json
+++ b/tests/fixtures/a10.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Queen Street","number":"1","town":"Auckland","number_first":true,"place":"1 Queen Street, Auckland"}

--- a/tests/fixtures/a11.in.json
+++ b/tests/fixtures/a11.in.json
@@ -1,0 +1,11 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "12",
+    "road": "Main Street",
+    "city": "Springfield",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a11.out.json
+++ b/tests/fixtures/a11.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Main Street","number":"12","town":"Springfield","number_first":false,"place":"Main Street 12, Springfield"}

--- a/tests/fixtures/a12.in.json
+++ b/tests/fixtures/a12.in.json
@@ -1,0 +1,12 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "1600",
+    "road": "Pennsylvania Avenue Northwest",
+    "city": "Washington",
+    "country_code": "us",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a12.out.json
+++ b/tests/fixtures/a12.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Pennsylvania Avenue Northwest","number":"1600","town":"Washington","number_first":true,"place":"1600 Pennsylvania Avenue Northwest, Washington"}

--- a/tests/fixtures/a15.in.json
+++ b/tests/fixtures/a15.in.json
@@ -1,0 +1,12 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "1600",
+    "road": "Pennsylvania Avenue Northwest",
+    "country_code": "us",
+    "ISO3166-2-lvl4": "US-DC",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a15.out.json
+++ b/tests/fixtures/a15.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Pennsylvania Avenue Northwest","number":"1600","town":"","number_first":true,"place":"1600 Pennsylvania Avenue Northwest"}

--- a/tests/fixtures/a16.in.json
+++ b/tests/fixtures/a16.in.json
@@ -1,0 +1,11 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "12",
+    "city": "Springfield",
+    "country_code": "nl",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a16.out.json
+++ b/tests/fixtures/a16.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"","number":"12","town":"Springfield","number_first":false,"place":"12, Springfield"}

--- a/tests/fixtures/a3.in.json
+++ b/tests/fixtures/a3.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "12",
+    "road": "Venweg",
+    "village": "Kronenberg",
+    "country_code": "nl",
+    "ISO3166-2-lvl4": "NL-LI",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a3.out.json
+++ b/tests/fixtures/a3.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Venweg","number":"12","town":"Kronenberg","number_first":false,"place":"Venweg 12, Kronenberg"}

--- a/tests/fixtures/a4.in.json
+++ b/tests/fixtures/a4.in.json
@@ -1,0 +1,11 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "road": "Spandauer Straße",
+    "city": "Berlin",
+    "country_code": "de",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a4.out.json
+++ b/tests/fixtures/a4.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Spandauer Straße","number":"","town":"Berlin","number_first":false,"place":"Spandauer Straße, Berlin"}

--- a/tests/fixtures/a5.in.json
+++ b/tests/fixtures/a5.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "10",
+    "road": "Bedford Street",
+    "village": "Westport",
+    "country_code": "ca",
+    "ISO3166-2-lvl4": "CA-ON",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a5.out.json
+++ b/tests/fixtures/a5.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Bedford Street","number":"10","town":"Westport, ON","number_first":true,"place":"10 Bedford Street, Westport, ON"}

--- a/tests/fixtures/a6.in.json
+++ b/tests/fixtures/a6.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "223",
+    "road": "William Street",
+    "city": "Melbourne",
+    "country_code": "au",
+    "ISO3166-2-lvl4": "AU-VIC",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a6.out.json
+++ b/tests/fixtures/a6.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"William Street","number":"223","town":"Melbourne, VIC","number_first":true,"place":"223 William Street, Melbourne, VIC"}

--- a/tests/fixtures/a7.in.json
+++ b/tests/fixtures/a7.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "115",
+    "road": "New Cavendish Street",
+    "city": "London",
+    "country_code": "gb",
+    "ISO3166-2-lvl4": "GB-ENG",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a7.out.json
+++ b/tests/fixtures/a7.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"New Cavendish Street","number":"115","town":"London","number_first":true,"place":"115 New Cavendish Street, London"}

--- a/tests/fixtures/a8.in.json
+++ b/tests/fixtures/a8.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "17",
+    "road": "Rue de Rivoli",
+    "city": "Paris",
+    "country_code": "fr",
+    "ISO3166-2-lvl4": "FR-IDF",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a8.out.json
+++ b/tests/fixtures/a8.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Rue de Rivoli","number":"17","town":"Paris","number_first":true,"place":"17 Rue de Rivoli, Paris"}

--- a/tests/fixtures/a9.in.json
+++ b/tests/fixtures/a9.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "29",
+    "road": "Nassau Street",
+    "city": "Dublin",
+    "country_code": "ie",
+    "ISO3166-2-lvl4": "IE-D",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/a9.out.json
+++ b/tests/fixtures/a9.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Nassau Street","number":"29","town":"Dublin","number_first":true,"place":"29 Nassau Street, Dublin"}

--- a/tests/fixtures/iso_bare.in.json
+++ b/tests/fixtures/iso_bare.in.json
@@ -1,0 +1,13 @@
+{
+  "display_name": "leak-display",
+  "address": {
+    "house_number": "1",
+    "road": "Main",
+    "city": "Washington",
+    "country_code": "us",
+    "ISO3166-2-lvl4": "US",
+    "postcode": "leak-postcode",
+    "county": "leak-county",
+    "country": "leak-country"
+  }
+}

--- a/tests/fixtures/iso_bare.out.json
+++ b/tests/fixtures/iso_bare.out.json
@@ -1,0 +1,1 @@
+{"ok":true,"street":"Main","number":"1","town":"Washington","number_first":true,"place":"1 Main, Washington"}

--- a/tests/place.sh
+++ b/tests/place.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# Formatter and cmd_place tests. No network. No personal coordinates.
+set -euo pipefail
+
+root=$(cd "$(dirname -- "$0")/.." && pwd)
+jq_prog="$root/bin/place.jq"
+tesla="$root/bin/tesla"
+fail=0
+
+pass() { printf 'ok  %s\n' "$1"; }
+bad()  { printf 'not ok  %s\n' "$1"; fail=1; }
+
+[ -f "$jq_prog" ] || { echo "missing $jq_prog"; exit 1; }
+
+# --- place.jq fixtures -------------------------------------------------------
+
+for inp in "$root"/tests/fixtures/a*.in.json "$root"/tests/fixtures/iso_bare.in.json; do
+  [ -f "$inp" ] || continue
+  base=$(basename "$inp" .in.json)
+  exp="$root/tests/fixtures/$base.out.json"
+  got=$(jq -c -f "$jq_prog" "$inp")
+  want=$(jq -c . "$exp")
+  if [ "$got" = "$want" ]; then
+    pass "format $base"
+  else
+    bad "format $base"
+    printf '  got  %s\n  want %s\n' "$got" "$want"
+  fi
+  case "$got" in
+    *leak-display*|*leak-postcode*|*leak-county*|*leak-country*)
+      bad "format $base leaked extra keys"
+      ;;
+  esac
+  lines=$(printf '%s\n' "$got" | wc -l)
+  [ "$lines" -eq 1 ] || bad "format $base not one line ($lines)"
+done
+
+# --- PLACE_CACHE_USABLE from bin/tesla, never source tesla -------------------
+
+expr=$(grep -m1 '^PLACE_CACHE_USABLE=' "$tesla") || {
+  bad "PLACE_CACHE_USABLE assignment missing in bin/tesla"
+  expr='PLACE_CACHE_USABLE="false"'
+}
+eval "$expr"
+
+usable() { printf '%s' "$1" | jq -e "$PLACE_CACHE_USABLE" >/dev/null 2>&1; }
+
+old='{"ok":true,"street":"Main Street","number":"12","town":"Springfield","place":"Main Street 12, Springfield"}'
+if usable "$old"; then bad "A13 old cache must miss"; else pass "A13 old cache miss"; fi
+
+hit=$(jq -c . "$root/tests/fixtures/a1.out.json")
+if usable "$hit"; then pass "A13b usable cache"; else bad "A13b usable cache"; fi
+
+if usable '{"ok":false,"number_first":true}'; then bad "A13c ok false"; else pass "A13c ok false"; fi
+if usable '{"number_first":true}'; then bad "A13c ok missing"; else pass "A13c ok missing"; fi
+
+# --- cmd_place, isolated dirs, stub curl -------------------------------------
+
+if [ ! -x "$tesla" ]; then
+  echo "skip cmd_place: bin/tesla not executable"
+  [ "$fail" -eq 0 ]
+  exit "$fail"
+fi
+
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+export OMARCHY_TESLA_CACHE_DIR="$work/cache"
+export OMARCHY_TESLA_CONFIG_DIR="$work/config"
+mkdir -p "$work/bin" "$OMARCHY_TESLA_CACHE_DIR/places" "$OMARCHY_TESLA_CONFIG_DIR"
+
+# Record curl invocations; behaviour comes from CURL_MODE.
+: > "$work/curl.log"
+cat > "$work/bin/curl" <<'EOS'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${CURL_LOG:?}"
+case "${CURL_MODE:-fail}" in
+  fail) exit 1 ;;
+  a1) cat "${A1_IN:?}" ;;
+  *) exit 1 ;;
+esac
+EOS
+chmod +x "$work/bin/curl"
+export CURL_LOG="$work/curl.log"
+export A1_IN="$root/tests/fixtures/a1.in.json"
+export PATH="$work/bin:$PATH"
+
+run_place() { "$tesla" place 38.8977 -77.0365; }
+
+# tesla rounds with %.4f
+key=$(awk -v a=38.8977 -v b=-77.0365 'BEGIN { printf "%.4f_%.4f", a, b }')
+seed="$OMARCHY_TESLA_CACHE_DIR/places/$key.json"
+printf '%s\n' "$hit" > "$seed"
+: > "$CURL_LOG"
+export CURL_MODE=fail
+out=$(run_place)
+if [ "$out" = "$hit" ] && [ ! -s "$CURL_LOG" ]; then
+  pass "cmd_place A13b stdout is seeded JSON, no curl"
+else
+  bad "cmd_place A13b"
+  printf '  out=%s\n  curl_log=%s\n' "$out" "$(cat "$CURL_LOG")"
+fi
+lines=$(printf '%s\n' "$out" | wc -l)
+[ "$lines" -eq 1 ] || bad "cmd_place A13b not one line"
+
+# A13: unusable old file, stub curl fails, must not return the old object
+printf '%s\n' "$old" > "$seed"
+: > "$CURL_LOG"
+export CURL_MODE=fail
+out=$(run_place) || true
+if printf '%s' "$out" | jq -e '.ok == false' >/dev/null 2>&1 \
+   && ! printf '%s' "$out" | grep -q 'Main Street' \
+   && [ "$(cat "$seed")" = "$old" ]; then
+  pass "cmd_place A13 unusable cache not returned"
+else
+  bad "cmd_place A13 unusable cache"
+  printf '  out=%s\n  seed=%s\n' "$out" "$(cat "$seed")"
+fi
+
+# Cache miss, success: curl returns A1 fixture
+rm -f "$seed"
+: > "$CURL_LOG"
+export CURL_MODE=a1
+out=$(run_place)
+want=$(jq -c . "$root/tests/fixtures/a1.out.json")
+if [ "$out" = "$want" ] && [ -f "$seed" ] && [ "$(cat "$seed")" = "$want" ]; then
+  pass "cmd_place miss writes and prints A1 contract"
+else
+  bad "cmd_place miss-success"
+  printf '  out=%s\n  file=%s\n  want=%s\n' "$out" "$(cat "$seed" 2>/dev/null || echo missing)" "$want"
+fi
+
+# Missing place.jq
+copy="$work/lonely"
+mkdir -p "$copy"
+cp "$tesla" "$copy/tesla"
+chmod +x "$copy/tesla"
+: > "$CURL_LOG"
+export CURL_MODE=a1
+rm -f "$seed"
+out=$("$copy/tesla" place 38.8977 -77.0365) || true
+if printf '%s' "$out" | jq -e '.ok == false' >/dev/null 2>&1 \
+   && [ ! -f "$seed" ] \
+   && [ ! -s "$CURL_LOG" ]; then
+  pass "cmd_place missing place.jq fails without cache write"
+else
+  bad "cmd_place missing place.jq"
+  printf '  out=%s\n  curl_log=%s\n' "$out" "$(cat "$CURL_LOG")"
+fi
+
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
The glance line was joining `{street} {number}, {town}`, which is Dutch order. A US pin showed as `Pennsylvania Avenue Northwest 1600, Washington` instead of `1600 Pennsylvania Avenue Northwest, Washington, DC`. The details grid said tyres, and an open rear trunk was `the boot`.

**Address follows the pin**, not the desktop. Nominatim already returns `country_code` and `ISO3166-2-lvl4`. Number-first for US, CA, GB, IE, AU, NZ, FR. Region suffix for US, CA, AU. Everything else, including NL and DE, keeps the current order. A moving car still drops the house number.

**Copy follows `Qt.locale().name`.** `en_US` and `en_CA` get `tires` and `the trunk`. Other locales keep `tyres` and `the boot`. The script still emits `the boot` as a token. JSON keys stay `tyres` / `tyre_unit`. No new setting.

Formatting lives in `bin/place.jq`. Old place-cache files without `number_first` are a miss, so a parked US car gets one refetch.

`tests/place.sh` covers the formatter and cache paths with no network. QML copy is a short checklist in `tests/MANUAL.md`.

Nominatim interpolates two-digit house numbers on some US TIGER streets that are numbered in three digits. That is OSM data, not this join. Happy to follow up separately if you want to drop interpolated numbers or switch geocoders.