### PR TITLE
Add multi-car switching

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -63,7 +63,8 @@ Panel {
 
   // ----------------------------------------------------------------- settings
 
-  readonly property string vin: setting("vin", "")
+  readonly property string configuredVin: setting("vin", "")
+  property string selectedVin: configuredVin
   readonly property int panelWidth: setting("panelWidth", 380)
   readonly property int mapZoom: setting("mapZoom", 16)
   readonly property string mapStyle: setting("mapStyle", "Auto")
@@ -120,7 +121,7 @@ Panel {
     var base = [root.script,
                 "--park-throttle", String(root.parkThrottleMinutes * 60),
                 "--tile-url", root.tileUrl]
-    if (root.vin !== "") base = base.concat(["--vin", root.vin])
+    if (root.selectedVin !== "") base = base.concat(["--vin", root.selectedVin])
     return base.concat(args)
   }
 
@@ -129,6 +130,10 @@ Panel {
   // What the free poll last said: "online", "asleep", "offline", or "" before
   // the first answer.
   property string carState: ""
+  // `state` supplies these without waking any car, so the selector can be
+  // drawn before a full reading is available.
+  property string selectedCarName: "Tesla"
+  property var availableCars: []
   // The last full reading, from `tesla car`. Null until one lands.
   property var reading: null
   // The tile plan for the position in `reading`.
@@ -198,12 +203,18 @@ Panel {
         } catch (e) {
           return
         }
-        // Read before the ok check, because `car` can succeed at showing you
-        // the last known position and still have something to report about
-        // why it is the last known one.
         root.errorText = data.error || ""
         root.errorHint = data.hint || ""
         if (data.ok !== true) return
+        if (!data.fixture && root.selectedVin !== ""
+            && String(data.vin) !== root.selectedVin) return
+
+        // An empty configured VIN means Tesla's first car. Once it answers,
+        // make that choice explicit so every later request and cache lookup is
+        // tied to the same car.
+        if (root.selectedVin === "") root.selectedVin = String(data.vin)
+        root.selectedCarName = data.name || "Tesla"
+        root.availableCars = data.vehicles || []
 
         var was = root.carState
         root.carState = data.state
@@ -239,6 +250,7 @@ Panel {
         root.errorText = data.error || ""
         root.errorHint = data.hint || ""
         if (data.ok !== true) return
+        if (!data.fixture && data.vin && String(data.vin) !== root.selectedVin) return
         root.reading = data
       }
     }
@@ -248,6 +260,30 @@ Panel {
     if (carProc.running) return
     carProc.command = root.cmd(force ? ["car", "--force"] : ["car"])
     carProc.running = true
+  }
+
+  readonly property bool switchBusy: stateProc.running || carProc.running
+    || wakeProc.running || mapProc.running || placeProc.running
+
+  function selectCar(vin, name) {
+    vin = String(vin || "")
+    if (vin === "" || vin === selectedVin || switchBusy) return
+
+    selectedVin = vin
+    selectedCarName = name || "Tesla"
+    carState = ""
+    reading = null
+    mapPlan = null
+    placeStreet = ""
+    placeNumber = ""
+    placeTown = ""
+    errorText = ""
+    errorHint = ""
+    mapDebounce.stop()
+    placeDebounce.stop()
+
+    stateProc.running = true
+    refresh(false)
   }
 
   // Only while the car is awake on somebody else's account. A parked car gets
@@ -404,19 +440,7 @@ Panel {
   // about when "it is probably still there" turns into "it was there".
   readonly property bool stale: readingAge > 3600
 
-  readonly property string carName: {
-    if (!hasReading) return "Tesla"
-    if (reading.name && reading.name !== "Tesla") return reading.name
-    // Falls back to what the car is rather than a name nobody set: "MODEL S
-    // 100D" beats "TESLA" at the top of a panel about one specific car.
-    var type = String(reading.car_type || "")
-    var model = type.indexOf("models") === 0 ? "Model S"
-              : type.indexOf("modelx") === 0 ? "Model X"
-              : type.indexOf("model3") === 0 ? "Model 3"
-              : type.indexOf("modely") === 0 ? "Model Y"
-              : "Tesla"
-    return reading.trim ? model + " " + String(reading.trim).toUpperCase() : model
-  }
+  readonly property string carName: selectedCarName || "Tesla"
 
   readonly property string stateWord: {
     if (errorText !== "") return errorText
@@ -519,10 +543,10 @@ Panel {
     dimmed: root.asleep || root.errorText !== ""
     tooltipText: {
       if (root.errorText !== "") return root.plain("Dude, where's my car? " + root.errorText)
-      if (!root.hasReading) return "Dude, where's my car?"
-      if (root.driving) return root.plain(root.summary)
-      if (root.place !== "") return root.plain("Parked at " + root.place)
-      return root.plain(root.summary)
+      if (!root.hasReading) return root.plain(root.carName)
+      if (root.driving) return root.plain(root.carName + ": " + root.summary)
+      if (root.place !== "") return root.plain(root.carName + ": parked at " + root.place)
+      return root.plain(root.carName + ": " + root.summary)
     }
 
     onPressed: function(b) {
@@ -563,14 +587,11 @@ Panel {
         width: parent.width
         height: Math.max(title.implicitHeight, badge.height)
 
-        // The plugin is called Tesla everywhere it is listed, because that is
-        // what you look for when you go hunting for it. The joke is here, at
-        // the top of the panel, where it is the actual question being asked.
         PanelSectionHeader {
           id: title
           anchors.left: parent.left
           anchors.verticalCenter: parent.verticalCenter
-          text: "DUDE, WHERE'S MY CAR?"
+          text: root.carName
           foreground: root.foreground
           fontFamily: root.fontFamily
         }
@@ -609,6 +630,36 @@ Panel {
             font.pixelSize: Style.font.caption
             color: root.foreground
             opacity: 0.7
+          }
+        }
+      }
+
+      Row {
+        id: carSelector
+        visible: root.availableCars.length > 1
+        width: parent.width
+        spacing: Style.space(6)
+
+        readonly property real buttonWidth: root.availableCars.length > 0
+          ? (width - spacing * (root.availableCars.length - 1)) / root.availableCars.length
+          : 0
+
+        Repeater {
+          model: root.availableCars
+
+          Button {
+            required property var modelData
+
+            width: carSelector.buttonWidth
+            text: modelData.name || "Tesla"
+            tooltipText: "VIN " + modelData.vin
+            selected: String(modelData.vin) === root.selectedVin
+            enabled: !root.switchBusy
+            bordered: true
+            foreground: root.foreground
+            fontFamily: root.fontFamily
+            fontSize: Style.font.bodySmall
+            onClicked: root.selectCar(modelData.vin, modelData.name)
           }
         }
       }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Tesla
 
-An [Omarchy](https://omarchy.org) bar widget for a Tesla. The bar shows the
+An [Omarchy](https://omarchy.org) bar widget for your Teslas. The bar shows the
 Tesla mark and nothing else. Click it and a panel comes down with a map of
-where the car is, which way it is pointing, how full the battery is, how far
+where the selected car is, which way it is pointing, how full the battery is, how far
 that gets you, and the handful of things you actually end up wondering about a
 parked car.
 
@@ -175,6 +175,8 @@ corner of your eye.
 
 **In the panel**, top to bottom:
 
+- The car's name. Accounts with more than one car also get a row of car buttons;
+  each button switches the panel to that VIN without changing the saved default.
 - A map centred on the car, with it drawn as an arrow pointing the way it is
   facing, the same heading the Tesla app shows under Location. The marker
   pulses while it is moving.
@@ -254,7 +256,7 @@ secrets somewhere else.
 
 | Setting | Default | What it does |
 | --- | --- | --- |
-| VIN | empty | Which car, when the account has more than one. Empty takes the first. |
+| VIN | empty | Which car is initially selected. Empty takes the first; switch cars in the panel. |
 | Map | Auto | Follows the theme. Or force CARTO dark, CARTO light, or OpenStreetMap's own tiles. |
 | Zoom | 16 | 16 shows the street and its neighbours. Lower for which town, higher for which parking space. |
 | Panel width | 380 | Sizes the whole panel; everything else is measured off the map. |

--- a/bin/tesla
+++ b/bin/tesla
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# tesla: read one Tesla, for the bar widget to call.
+# tesla: read a Tesla, for the bar widget to call.
 #
 # Everything that talks to Tesla is here, so the QML never holds a credential
 # and never decides on its own to touch the car.
@@ -103,14 +103,15 @@ need curl
 need jq
 need awk
 need openssl
+need md5sum
 
 # Both trees are private, and not only for the tokens. The cache is a record
-# of where the car has been: car.json carries the last position, and the
+# of where the cars have been: cars/*.json carries each last position, and the
 # geocode cache spells the coordinates out in its own filenames, so a `ls` of
 # it is a movement log. On a machine with a second account, mode 755 hands
 # that over for the reading. The chmod covers installs that predate this.
-( umask 077; mkdir -p "$CONFIG_DIR" "$CACHE_DIR/tiles" "$CACHE_DIR/places" )
-chmod 700 "$CONFIG_DIR" "$CACHE_DIR" "$CACHE_DIR/tiles" "$CACHE_DIR/places" 2>/dev/null || true
+( umask 077; mkdir -p "$CONFIG_DIR" "$CACHE_DIR/cars" "$CACHE_DIR/tiles" "$CACHE_DIR/places" )
+chmod 700 "$CONFIG_DIR" "$CACHE_DIR" "$CACHE_DIR/cars" "$CACHE_DIR/tiles" "$CACHE_DIR/places" 2>/dev/null || true
 
 now() { date +%s; }
 
@@ -419,8 +420,8 @@ api_hint() {
 # for it is a round trip the bar would otherwise make every time it polls.
 # `/api/1/vehicles` is the obvious endpoint and Tesla has retired it for owner
 # tokens; `/api/1/products` still answers and carries the same fields.
-vehicle_json() {
-  local cache="$CACHE_DIR/vehicle.json" age response
+vehicle_list_json() {
+  local cache="$CACHE_DIR/vehicles.json" age response vehicles
 
   if [ -r "$cache" ]; then
     age=$(( $(now) - $(stat -c %Y "$cache" 2>/dev/null || echo 0) ))
@@ -429,15 +430,33 @@ vehicle_json() {
 
   response=$(api products) || return 2
   [ -z "$(api_error)" ] || return 3
-  local picked
-  picked=$(printf '%s' "$response" | jq -c --arg vin "$VIN" '
-    [.response[]? | select(.vin != null)]
-    | (if $vin == "" then .[0] else (map(select(.vin == $vin)) | .[0]) end)
+  vehicles=$(printf '%s' "$response" | jq -c '[.response[]? | select(.vin != null)]')
+  [ "$(printf '%s' "$vehicles" | jq -r 'length')" -gt 0 ] || return 1
+  printf '%s' "$vehicles" | write_private "$cache"
+  printf '%s' "$vehicles"
+}
+
+vehicle_json() {
+  local vehicles picked
+  vehicles=$(vehicle_list_json) || return $?
+  picked=$(printf '%s' "$vehicles" | jq -c --arg vin "$VIN" '
+    if $vin == "" then .[0] else (map(select(.vin == $vin)) | .[0]) end
     // empty')
 
   [ -n "$picked" ] || return 1
-  printf '%s' "$picked" | write_private "$cache"
   printf '%s' "$picked"
+}
+
+vehicle_error() {
+  local error
+  error=$(api_error)
+  if [ -n "$error" ]; then printf '%s' "$error"; else printf '%s' "car not found"; fi
+}
+
+vehicle_hint() {
+  local hint
+  hint=$(api_hint)
+  if [ -n "$hint" ]; then printf '%s' "$hint"; else printf '%s' "check that the VIN belongs to this account"; fi
 }
 
 # The state poll. This is the one the bar runs on a timer, and it must stay
@@ -445,13 +464,16 @@ vehicle_json() {
 cmd_state() {
   if has_fixture; then
     jq -c --arg at "$(now)" '{ok: true, at: ($at|tonumber), fixture: true,
-                              state: (.state // "online"), id: "fixture",
-                              vin: (.vin // "FIXTURE"), name: (.name // "Tesla")}' "$(fixture_path)"
+                               state: (.state // "online"), id: "fixture",
+                               vin: (.vin // "FIXTURE"), name: (.name // "Tesla"),
+                               vehicles: [{vin: (.vin // "FIXTURE"),
+                                           name: (.name // "Tesla")}]} ' "$(fixture_path)"
     return 0
   fi
 
-  local vehicle
-  vehicle=$(vehicle_json) || fail_json "$(api_error)" "$(api_hint)"
+  local vehicles vehicle
+  vehicles=$(vehicle_list_json) || fail_json "$(vehicle_error)" "$(vehicle_hint)"
+  vehicle=$(vehicle_json) || fail_json "$(vehicle_error)" "$(vehicle_hint)"
 
   local id state
   id=$(printf '%s' "$vehicle" | jq -r '.id_s // (.id|tostring)')
@@ -462,10 +484,15 @@ cmd_state() {
   [ -z "$(api_error)" ] || fail_json "$(api_error)" "$(api_hint)"
   [ -n "$state" ] || state=$(printf '%s' "$vehicle" | jq -r '.state // "unknown"')
 
-  jq -cn --argjson v "$vehicle" --arg state "$state" --arg at "$(now)" '
+  jq -cn --argjson v "$vehicle" --argjson vehicles "$vehicles" \
+    --arg state "$state" --arg at "$(now)" '
     {ok: true, state: $state, at: ($at|tonumber),
-     id: ($v.id_s // ($v.id|tostring)), vin: $v.vin,
-     name: (if ($v.display_name // "") == "" then "Tesla" else $v.display_name end)}'
+      id: ($v.id_s // ($v.id|tostring)), vin: $v.vin,
+      name: (if ($v.display_name // "") == "" then "Tesla" else $v.display_name end),
+      vehicles: ($vehicles | map({
+        vin: .vin,
+        name: (if (.display_name // "") == "" then "Tesla" else .display_name end)
+      }))}'
 }
 
 # ------------------------------------------------------------------ readings
@@ -572,6 +599,27 @@ reading_json() {
 # asking the car is even possible. Then the throttle, because a parked car
 # that answered ten minutes ago has not moved and does not need asking again.
 # Only then the expensive call.
+car_cache_path() {
+  local vehicle="$1" vin key
+  vin=$(printf '%s' "$vehicle" | jq -r '.vin // empty')
+  key=$(printf '%s' "$vin" | md5sum | awk '{print $1}')
+  printf '%s/cars/%s.json' "$CACHE_DIR" "$key"
+}
+
+read_car_cache() {
+  local vehicle="$1" cache legacy="$CACHE_DIR/car.json" vin legacy_vin
+  cache=$(car_cache_path "$vehicle")
+  if [ -r "$cache" ]; then cat "$cache"; return 0; fi
+
+  # Keep the last reading from pre-multi-car installs, but only for the VIN it
+  # actually belongs to, until a fresh reading replaces it in the new cache.
+  [ -r "$legacy" ] || return 1
+  vin=$(printf '%s' "$vehicle" | jq -r '.vin // empty')
+  legacy_vin=$(jq -r '.vin // empty' "$legacy" 2>/dev/null)
+  [ -n "$vin" ] && [ "$legacy_vin" = "$vin" ] || return 1
+  cat "$legacy"
+}
+
 cmd_car() {
   if has_fixture; then
     serve_fixture
@@ -579,16 +627,15 @@ cmd_car() {
   fi
 
   local vehicle
-  vehicle=$(vehicle_json) || serve_cache_or_fail
+  vehicle=$(vehicle_json) || fail_json "$(vehicle_error)" "$(vehicle_hint)"
 
   local id cache state cached
   id=$(printf '%s' "$vehicle" | jq -r '.id_s // (.id|tostring)')
-  cache="$CACHE_DIR/car.json"
-  cached=""
-  [ -r "$cache" ] && cached=$(cat "$cache")
+  cache=$(car_cache_path "$vehicle")
+  cached=$(read_car_cache "$vehicle") || cached=""
 
   state=$(api "vehicles/$id" | jq -r '.response.state // empty' 2>/dev/null)
-  [ -z "$(api_error)" ] || serve_cache_or_fail
+  [ -z "$(api_error)" ] || serve_cache_or_fail "$vehicle"
   [ -n "$state" ] || state=$(printf '%s' "$vehicle" | jq -r '.state // "unknown"')
 
   # Asleep or offline: the reading on disk is the only answer there is, and it
@@ -643,8 +690,8 @@ cmd_car() {
 # The last reading goes out with the complaint attached, so the panel can show
 # both rather than going blank about a car parked in a perfectly known place.
 serve_cache_or_fail() {
-  local cached=""
-  [ -r "$CACHE_DIR/car.json" ] && cached=$(cat "$CACHE_DIR/car.json")
+  local vehicle="$1" cached=""
+  cached=$(read_car_cache "$vehicle") || cached=""
 
   if [ -z "$cached" ]; then
     fail_json "$(api_error)" "$(api_hint)"
@@ -825,7 +872,7 @@ cmd_place() {
 
 usage() {
   cat <<'EOF'
-tesla: read one Tesla, without keeping it awake.
+tesla: read your Teslas, without keeping them awake.
 
   token                     paste a refresh token from a token app. The easy way
   login                     sign in through the browser instead. Needs devtools

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "jankeesvw.tesla",
   "name": "Tesla",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": "Jankees van Woezik",
   "description": "Your Tesla in the bar: where it is, how full it is, and how far that gets you",
   "homepage": "https://github.com/jankeesvw/omarchy-tesla",
@@ -35,7 +35,7 @@
         "type": "string",
         "label": "VIN",
         "defaultValue": "",
-        "description": "Which car, when the account has more than one. Empty picks the first one Tesla lists, which is the right answer for almost everybody."
+        "description": "Which car is initially selected when the account has more than one. Empty picks the first one Tesla lists. Cars can then be switched from the panel."
       },
       {
         "key": "mapStyle",


### PR DESCRIPTION
## Summary

- include the account's vehicle names and VINs in the cheap `tesla state` response
- show the selected car name and a selector when the account has multiple cars
- keep readings cached per VIN so switching cars cannot show another car's stale data
- preserve the VIN setting as the initial selection and document the new behavior

## Validation

- `bash -n bin/tesla`
- `jq empty manifest.json`
- `git diff --check`
- fixture-mode checks for state and car responses
- verified selection against an account with two vehicles
- reloaded successfully in the running Omarchy Quickshell instance with no plugin errors

## Preview
<img width="382" height="708" alt="image" src="https://github.com/user-attachments/assets/3bbdb303-422c-4223-bf18-6164919d221a" />
<img width="380" height="710" alt="image" src="https://github.com/user-attachments/assets/786344af-3b7a-4801-9618-7672441d2c5e" />

