### PR TITLE
Support Tesla China regional endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ Then paste the **refresh** token in:
 It spends the token on an access token there and then, so if it says you are
 signed in, you are.
 
+China-region accounts are detected from the token issuer automatically. Their
+tokens are refreshed through `auth.tesla.cn` and their car data is read from
+Tesla's China Owner API; no region setting is needed.
+
 There is also `tesla login`, which runs the whole browser flow itself. It works,
 but Tesla has taken `https://auth.tesla.com/void/callback` off the allowlist for
 the `ownerapi` client, so the only accepted redirect left is `tesla://auth/callback`

--- a/bin/tesla
+++ b/bin/tesla
@@ -30,7 +30,9 @@
 set -uo pipefail
 
 readonly OWNER_API="https://owner-api.teslamotors.com/api/1"
+readonly OWNER_API_CN="https://owner-api.vn.cloud.tesla.cn/api/1"
 readonly AUTH="https://auth.tesla.com/oauth2/v3"
+readonly AUTH_CN="https://auth.tesla.cn/oauth2/v3"
 readonly CLIENT_ID="ownerapi"
 # Tesla took https://auth.tesla.com/void/callback off the allowlist for
 # client_id=ownerapi; the authorize call now 403s before the login form is even
@@ -191,6 +193,51 @@ refresh_token() {
   read_first_line "$CONFIG_DIR/refresh-token"
 }
 
+# Read only the issuer needed for regional routing. JWT claims are untrusted,
+# so callers below use this solely to choose between hard-coded Tesla hosts.
+jwt_issuer() {
+  local token="$1" payload padding
+
+  payload=${token#*.}
+  [ "$payload" != "$token" ] || return 1
+  payload=${payload%%.*}
+  case "$payload" in ''|*[!A-Za-z0-9_-]*) return 1 ;; esac
+
+  case $((${#payload} % 4)) in
+    0) padding="" ;;
+    2) padding="==" ;;
+    3) padding="=" ;;
+    *) return 1 ;;
+  esac
+
+  printf '%s%s' "$payload" "$padding" | tr '_-' '/+' \
+    | openssl base64 -d -A 2>/dev/null \
+    | jq -er '.iss | strings | select(length > 0)' 2>/dev/null
+}
+
+# Refresh tokens are issuer-bound. China-region accounts receive tokens from
+# auth.tesla.cn, and that endpoint—not auth.tesla.com—must mint their access
+# tokens.
+auth_for_refresh_token() {
+  local issuer
+  issuer=$(jwt_issuer "$1") || issuer=""
+
+  case "$issuer" in
+    https://auth.tesla.cn/oauth2/v3) printf '%s' "$AUTH_CN" ;;
+    *) printf '%s' "$AUTH" ;;
+  esac
+}
+
+owner_api_for_access_token() {
+  local issuer
+  issuer=$(jwt_issuer "$1") || issuer=""
+
+  case "$issuer" in
+    https://auth.tesla.cn/oauth2/v3) printf '%s' "$OWNER_API_CN" ;;
+    *) printf '%s' "$OWNER_API" ;;
+  esac
+}
+
 # Refreshes when there is less than a minute left rather than at the moment of
 # expiry: a request that starts valid can still arrive expired.
 access_token() {
@@ -214,9 +261,10 @@ access_token() {
 # Tesla rotates the refresh token on some responses and dropping the new one
 # means the next refresh fails.
 mint_access_token() {
-  local refresh="$1" body response token expires_in new_refresh
+  local refresh="$1" auth body response token expires_in new_refresh
 
   [ -n "$refresh" ] || return 1
+  auth=$(auth_for_refresh_token "$refresh")
 
   # The token reaches jq on stdin for the same reason it reaches curl there:
   # `--arg rt "$refresh"` is an argument, and arguments are public. jq only
@@ -229,7 +277,7 @@ mint_access_token() {
 
   # Same reasoning as `api`, and more of it: this body carries the refresh
   # token, which is the account until it is revoked. It goes in on stdin.
-  response=$(printf '%s' "$body" | curl -sS $TLS_PIN -m 30 -X POST "$AUTH/token" \
+  response=$(printf '%s' "$body" | curl -sS $TLS_PIN -m 30 -X POST "$auth/token" \
     -H "Content-Type: application/json" \
     -H "User-Agent: $APP_UA" -H "X-Tesla-User-Agent: $APP_TAG" \
     --data-binary @- 2>/dev/null) || return 1
@@ -364,10 +412,11 @@ readonly API_ERROR_FILE="$CACHE_DIR/.last-error"
 api_error() { cat "$API_ERROR_FILE" 2>/dev/null; }
 
 api() {
-  local path="$1" method="${2:-GET}" token body
+  local path="$1" method="${2:-GET}" token owner_api body
   : > "$API_ERROR_FILE"
 
   token=$(access_token) || { printf 'not signed in' > "$API_ERROR_FILE"; return 2; }
+  owner_api=$(owner_api_for_access_token "$token")
 
   # A quote or a backslash would end the --config line early and turn the rest
   # of the token into curl options. Tesla's tokens are base64url and contain
@@ -387,7 +436,7 @@ api() {
     -H "User-Agent: $APP_UA" \
     -H "X-Tesla-User-Agent: $APP_TAG" \
     -H "Accept: application/json" \
-    "$OWNER_API/$path" 2>/dev/null) || { printf 'cannot reach Tesla' > "$API_ERROR_FILE"; return 1; }
+    "$owner_api/$path" 2>/dev/null) || { printf 'cannot reach Tesla' > "$API_ERROR_FILE"; return 1; }
 
   # Tesla says no in JSON, so an error body still parses and still has to be
   # noticed. Reading past it is how a widget ends up cheerfully reporting a

--- a/test/all
+++ b/test/all
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+bash -n "$ROOT/bin/tesla"
+"$ROOT/test/smoke"
+"$ROOT/test/regional-routing"

--- a/test/mock-curl
+++ b/test/mock-curl
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+url=""
+for arg in "$@"; do
+  printf '%s\n' "$arg" >> "$MOCK_CURL_LOG"
+  case "$arg" in
+    https://*) url="$arg" ;;
+  esac
+done
+
+# Consume request bodies and curl config from stdin without recording either:
+# both contain credentials in the real client.
+if [ ! -t 0 ]; then
+  while IFS= read -r _; do :; done
+fi
+
+case "$url" in
+  */oauth2/v3/token)
+    jq -cn --arg access "$MOCK_ACCESS_TOKEN" --arg refresh "$MOCK_REFRESH_TOKEN" \
+      '{access_token: $access, refresh_token: $refresh, expires_in: 28800}'
+    ;;
+  */api/1/products)
+    jq -cn '{response: [{id: 1, id_s: "1", vin: "TESTVIN", state: "offline"}]}'
+    ;;
+  */api/1/vehicles/1)
+    jq -cn '{response: {state: "offline"}}'
+    ;;
+  *)
+    printf 'unexpected mock curl URL: %s\n' "$url" >&2
+    exit 1
+    ;;
+esac

--- a/test/regional-routing
+++ b/test/regional-routing
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TESLA="$ROOT/bin/tesla"
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf -- "$TEST_TMP"' EXIT
+
+mkdir -p "$TEST_TMP/bin"
+ln -s "$ROOT/test/mock-curl" "$TEST_TMP/bin/curl"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+jwt() {
+  local issuer="$1" payload
+  payload=$(jq -cn --arg issuer "$issuer" '{iss: $issuer}' \
+    | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+  printf 'e30.%s.test-signature' "$payload"
+}
+
+run_region() {
+  local name="$1" issuer="$2" auth="$3" owner_api="$4"
+  local config="$TEST_TMP/$name/config" cache="$TEST_TMP/$name/cache"
+  local log="$TEST_TMP/$name/curl.log" refresh access output
+
+  mkdir -p "$config" "$cache"
+  : > "$log"
+  refresh=$(jwt "$issuer")
+  access=$(jwt "$issuer")
+
+  printf '%s\n' "$refresh" | env \
+    PATH="$TEST_TMP/bin:$PATH" \
+    OMARCHY_TESLA_CONFIG_DIR="$config" \
+    OMARCHY_TESLA_CACHE_DIR="$cache" \
+    MOCK_CURL_LOG="$log" \
+    MOCK_ACCESS_TOKEN="$access" \
+    MOCK_REFRESH_TOKEN="$refresh" \
+    "$TESLA" token >/dev/null
+
+  grep -Fxq "$auth/oauth2/v3/token" "$log" \
+    || fail "$name refresh did not use $auth"
+  [ "$(stat -c %a "$config/refresh-token")" = 600 ] \
+    || fail "$name refresh token is not mode 600"
+  [ "$(stat -c %a "$config/access-token")" = 600 ] \
+    || fail "$name access token is not mode 600"
+  grep -Fq "$refresh" "$log" \
+    && fail "$name refresh token appeared in curl arguments"
+
+  : > "$log"
+  output=$(env \
+    PATH="$TEST_TMP/bin:$PATH" \
+    OMARCHY_TESLA_CONFIG_DIR="$config" \
+    OMARCHY_TESLA_CACHE_DIR="$cache" \
+    MOCK_CURL_LOG="$log" \
+    MOCK_ACCESS_TOKEN="$access" \
+    MOCK_REFRESH_TOKEN="$refresh" \
+    "$TESLA" state)
+
+  [ "$(printf '%s' "$output" | jq -r '.ok')" = true ] \
+    || fail "$name state request failed"
+  [ "$(printf '%s' "$output" | jq -r '.state')" = offline ] \
+    || fail "$name state was not parsed"
+  grep -Fxq "$owner_api/api/1/products" "$log" \
+    || fail "$name products request did not use $owner_api"
+  grep -Fxq "$owner_api/api/1/vehicles/1" "$log" \
+    || fail "$name vehicle request did not use $owner_api"
+  grep -Fq "$access" "$log" \
+    && fail "$name access token appeared in curl arguments"
+
+  printf 'ok - %s routing\n' "$name"
+}
+
+run_region global "https://auth.tesla.com/oauth2/v3" \
+  "https://auth.tesla.com" "https://owner-api.teslamotors.com"
+run_region china "https://auth.tesla.cn/oauth2/v3" \
+  "https://auth.tesla.cn" "https://owner-api.vn.cloud.tesla.cn"
+run_region untrusted-issuer "https://attacker.invalid/oauth2/v3" \
+  "https://auth.tesla.com" "https://owner-api.teslamotors.com"
+
+printf 'regional routing tests passed\n'

--- a/test/smoke
+++ b/test/smoke
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+TESLA="$ROOT/bin/tesla"
+TEST_TMP=$(mktemp -d)
+trap 'rm -rf -- "$TEST_TMP"' EXIT
+
+CONFIG="$TEST_TMP/config"
+CACHE="$TEST_TMP/cache"
+mkdir -p "$CONFIG" "$CACHE"
+
+fail() {
+  printf 'FAIL: %s\n' "$*" >&2
+  exit 1
+}
+
+run() {
+  env OMARCHY_TESLA_CONFIG_DIR="$CONFIG" OMARCHY_TESLA_CACHE_DIR="$CACHE" \
+    "$TESLA" "$@"
+}
+
+jq -cn '{state: "offline", name: "Fixture", battery: 50, at: 1}' \
+  > "$CONFIG/fixture.json"
+
+output=$(run state)
+[ "$(printf '%s' "$output" | jq -r '.ok')" = true ] \
+  || fail "fixture state failed"
+[ "$(printf '%s' "$output" | jq -r '.fixture')" = true ] \
+  || fail "fixture state was not marked"
+
+output=$(run car)
+[ "$(printf '%s' "$output" | jq -r '.fixture')" = true ] \
+  || fail "fixture car failed"
+[ "$(printf '%s' "$output" | jq -r '.battery')" = 50 ] \
+  || fail "fixture car data changed"
+
+output=$(run map not-a-number 0 1 256 256)
+[ "$(printf '%s' "$output" | jq -r '.error')" = "map wants numbers" ] \
+  || fail "invalid map input was not rejected"
+
+output=$(run place not-a-number 0)
+[ "$(printf '%s' "$output" | jq -r '.error')" = "place wants numbers" ] \
+  || fail "invalid place input was not rejected"
+
+printf 'fake-refresh\n' > "$CONFIG/refresh-token"
+printf 'fake-access\n' > "$CONFIG/access-token"
+run logout >/dev/null
+[ ! -e "$CONFIG/refresh-token" ] && [ ! -e "$CONFIG/access-token" ] \
+  || fail "logout left credentials behind"
+
+run --help | grep -Fq 'without keeping it awake' \
+  || fail "help output is missing"
+
+printf 'smoke tests passed\n'


### PR DESCRIPTION
## Summary

- detect China-region accounts from the refresh/access token issuer
- route token refreshes to `auth.tesla.cn` and Owner API requests to `owner-api.vn.cloud.tesla.cn`
- restrict routing to hard-coded Tesla hosts and retain the existing global endpoints as the safe fallback
- document automatic China-region handling and add a self-contained regression suite

## Testing

- `./test/all`
  - command and fixture smoke tests
  - mocked global routing
  - mocked China routing
  - untrusted issuer fallback
  - credential file permissions and no-token-in-curl-arguments checks
- `shellcheck test/all test/mock-curl test/regional-routing test/smoke`
- `shellcheck -e SC2006,SC1001,SC2155,SC2317 bin/tesla` (the excluded findings predate this change)
- `omarchy plugin validate "$PWD"`
- live China-region account: refresh exchange succeeded and the read-only `state` request returned successfully

No live wake command or vehicle-data request was made.