### PR TITLE
Show the remaining range as the bar item

### DIFF
--- a/Panel.qml
+++ b/Panel.qml
@@ -535,15 +535,40 @@ Panel {
   // beside it while the car was moving, which made the bar shuffle every time
   // a car pulled away. A lot of movement in the corner of your eye to say
   // something the panel says better. The colour carries it instead.
-  implicitWidth: button.implicitWidth
+  // The remaining range as the bar item, as "183", in the same cell style the
+  // shell's battery widget uses for its percentage. The unit is in the tooltip
+  // and in the panel: the bar is for the number you glance at, and "183 mi" in
+  // a bar is two things to read where one would do.
+  //
+  // It costs the car nothing. This is the last reading the panel already holds,
+  // not another question asked of it, so the sleep policy is untouched — the
+  // number simply ages along with everything else the panel is showing.
+  // `showRange` off restores the bare mark.
+  readonly property bool showRange: setting("showRange", true)
+  readonly property string barRange:
+    showRange && hasReading && reading.range !== null && reading.range !== undefined
+      ? String(Math.round(reading.range))
+      : ""
+
+  implicitWidth: barRow.implicitWidth
   implicitHeight: button.implicitHeight
 
-  BarIconButton {
-    id: button
+  Row {
+    id: barRow
     anchors.left: parent.left
     anchors.top: parent.top
     anchors.bottom: parent.bottom
+    spacing: 0
+
+  BarIconButton {
+    id: button
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
     bar: root.bar
+    // The number is the widget. The mark only stands in while there is no
+    // reading to show — first start, or signed out — so there is always
+    // something in the bar to click.
+    visible: root.barRange === ""
 
     iconComponent: Component {
       TeslaMark {
@@ -580,11 +605,31 @@ Panel {
     }
   }
 
+  // The number. Same colour rules as the mark so the two read as one widget:
+  // green while driving, dimmed while asleep. Its own cell rather than text
+  // inside the icon slot because the mark is a Shape, not a glyph, and the
+  // shell's icon button only knows how to typeset one or the other.
+  WidgetButton {
+    id: rangeLabel
+    anchors.top: parent.top
+    anchors.bottom: parent.bottom
+    bar: root.bar
+    text: root.barRange
+    fontSize: Style.font.bodySmall
+    horizontalMargin: 6
+    active: root.driving
+    activeColor: root.liveGreen
+    dimmed: root.asleep || root.errorText !== ""
+    tooltipText: button.tooltipText
+    onPressed: function(b) { button.pressed(b) }
+  }
+  }
+
   // ------------------------------------------------------------------- panel
 
   PopupCard {
     id: popup
-    anchorItem: button
+    anchorItem: root.barRange !== "" ? rangeLabel : button
     bar: root.bar
     owner: root
     open: root.opened

--- a/manifest.json
+++ b/manifest.json
@@ -21,6 +21,7 @@
     "defaultSection": "right",
     "defaults": {
       "vin": "",
+      "showRange": true,
       "panelWidth": 380,
       "mapZoom": 16,
       "mapStyle": "Auto",
@@ -36,6 +37,13 @@
         "label": "VIN",
         "defaultValue": "",
         "description": "Which car is initially selected when the account has more than one. Empty picks the first one Tesla lists. Cars can then be switched from the panel."
+      },
+      {
+        "key": "showRange",
+        "type": "boolean",
+        "label": "Show the range in the bar",
+        "defaultValue": true,
+        "description": "Shows the remaining range as the bar item, just the number in whatever unit the car's own screen uses, instead of the Tesla mark. It is the last reading the panel already holds, so it asks the car for nothing extra; off gives you the bare mark."
       },
       {
         "key": "mapStyle",


### PR DESCRIPTION
The bar shows the number instead of the mark — `183`, bare, in whatever unit the car's own screen is set to, in the same cell style the shell's battery widget uses for its percentage.

The unit stays in the tooltip and in the panel. The bar is for the number you glance at, and `183 mi` is two things to read where one would do.

**It costs the car nothing.** This is the last reading the panel already holds, not another question asked of the car, so the sleep policy is completely untouched — the number ages along with everything else on show and goes stale with it. No new calls, no new timers.

**The mark is not gone.** It stands in whenever there is no reading yet — first start, or signed out — so there is always something in the bar to click, and the popup anchors to whichever of the two is actually visible. Both keep the mark's existing colour rules: green while driving, dimmed while asleep.

A `WidgetButton` rather than text in the existing icon slot, because the mark is a `Shape` rather than a glyph and `BarIconButton` typesets one or the other, never both.

New setting **`showRange`**, default on. Off gives back the bare mark, exactly as it is today.

---

Two notes, since it is your call and not mine:

- **Default.** I set it on because the number is the reason I glance at the widget, but flipping the default to off is a one-word change if you would rather the mark stayed what people see first.
- I have been running this for a few days on a Model 3. Happy to add a screenshot if useful, or to rework any of the wording — I tried to match the voice in the surrounding comments but it is your voice, not mine.

Thanks for the plugin. The sleep-policy chapter in the README is the best writing I have read in a repo this year.